### PR TITLE
use aes_string instead of aes

### DIFF
--- a/R/graphing.R
+++ b/R/graphing.R
@@ -7,7 +7,7 @@
 nanodrop_absorbtion_maxima <- function() {
   absorption_maxima <- data.frame(Substance = c("DNA", "Protein"), value = c(260, 280))
   ggplot2::geom_vline(data = absorption_maxima,
-                      ggplot2::aes(xintercept = value, 
-                                   linetype = Substance),
+                      ggplot2::aes_string(xintercept = "value", 
+                                          linetype = "Substance"),
                       show_guide = TRUE)
 }

--- a/R/pcr.R
+++ b/R/pcr.R
@@ -88,11 +88,11 @@ thermocycler_profile <- function(profile, repeats = NULL, width = NULL) {
     my_grob[["widths"]][panels] <- plyr::llply(width, grid::unit, units="null")
     return(my_grob)
   }
-  my_plot <- ggplot2::ggplot(data = data, ggplot2::aes(x = time, y = temp)) +
+  my_plot <- ggplot2::ggplot(data = data, ggplot2::aes_string(x = "time", y = "temp")) +
     ggplot2::geom_line() +
-    ggplot2::geom_text(size = 4, hjust=-.03, vjust=-.4, ggplot2::aes(label = stage)) +
-    ggplot2::geom_text(size = 4, hjust=-.03, vjust=1.4, ggplot2::aes(label = label)) +
-    ggplot2::facet_grid(.~ group, scales = "free_x") +
+    ggplot2::geom_text(size = 4, hjust=-.03, vjust=-.4, ggplot2::aes_string(label = "stage")) +
+    ggplot2::geom_text(size = 4, hjust=-.03, vjust=1.4, ggplot2::aes_string(label = "label")) +
+    ggplot2::facet_grid(. ~ group, scales = "free_x") +
     ggplot2::labs(x="Run Time (Minutes)", y = "Temperature (C)") +
     ggplot2::scale_y_continuous(expand = c(.2, 0)) +
     ggplot2::theme(#panel.margin = grid::unit(0, "inches"),


### PR DESCRIPTION
I ran into this with my first version of poppr. This generates a NOTE in CRAN check because of unidentified variables. `aes_string` is a much safer way of going about this.
